### PR TITLE
Changed behaviour when Series/DataArray is all NaN

### DIFF
--- a/openghg_calscales/functions.py
+++ b/openghg_calscales/functions.py
@@ -175,7 +175,7 @@ def convert(c, species, scale_original, scale_new):
 
     # Check that c is not all NaNs
     if np.isnan(c).all():
-        raise ValueError("c is all NaNs.")
+        return c
 
     # Construct graph
     G = _scale_graph(species.lower())


### PR DESCRIPTION
Now just returns the original dataset, rather than raising an error