### PR TITLE
Added conversions for SF6, HFC-125 and HFO-1234yf

### DIFF
--- a/openghg_calscales/data/convert_functions.csv
+++ b/openghg_calscales/data/convert_functions.csv
@@ -22,3 +22,13 @@ co,WMO-X2014A,CSIRO-94|CSIRO-1994|CSIRO94,(x+3.17)/0.9898,,,,,Dickon Young (pers
 chcl3,SIO-93|SIO-1993|SIO93,SIO-98|SIO-1998|SIO98,1.0032*x,,,,,Prinn et al. (2000). doi:10.1029/2000JD900141
 hcfc22,SIO-93|SIO-1993|SIO93,SIO-98|SIO-1998|SIO98,1.0053*x,,,,,Prinn et al. (2000). doi:10.1029/2000JD900141
 sf6,SIO-98|SIO-1998|SIO98,SIO-05|SIO-2005|SIO05,0.9994*x,,,,,Chris Harth (pers. comm. To Martin Vollmer 7/5/21)
+sf6,WMO- SF6-X2014|NOAA-2014|NOAA-14,SIO-05|SIO-2005|SIO05,x/1.002,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+sf6,WMO-SF6-X2006|NOAA-2006|NOAA-06,WMO- SF6-X2014|NOAA-2014|NOAA-14,2.6821e-3*x**2+9.7748e-1*x+3.5831e-2,,,,,NOAA ESRL (2014) https://gml.noaa.gov/ccl/sf6_scale.html as quoted in supplement of https://doi.org/10.5194/egusphere-2024-811
+sf6,NIES-2008|NIES-08,SIO-05|SIO-2005|SIO05,x/1.013,,,,,Saito et al. (2021) pers comm. Quoted in supplement of https://doi.org/10.5194/egusphere-2024-811
+sf6,SIO-05|SIO-2005|SIO05,METAS-2017|METAS-17,1.002*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+sf6,METAS-2017|METAS-17,WMO- SF6-X2014|NOAA-2014,1.000*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+hfc-125,SIO-14|SIO-2014|SIO14,METAS-2017|METAS-17,0.929*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+hfc-125,SIO-14|SIO-2014|SIO14,METAS-2015|METAS-15,0.963*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+hfc-125,SIO-14|SIO-2014|SIO14,NOAA-2008|NOAA-08,0.946*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+hfo-1234yf,Empa-2013|Empa-13,METAS-2017|METAS-17,0.910*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018
+hfo-1234yf,Empa-2013|Empa-13,METAS-2015|METAS-15,0.971*x,,,,,Guillevic et al. (2018) https://doi.org/10.5194/amt-11-3351-2018


### PR DESCRIPTION
From Guillevic et al. (2018, https://doi.org/10.5194/amt-11-3351-2018) and refs in Vojta et al. (2024, https://doi.org/10.5194/egusphere-2024-811)