### PR TITLE
Added dependencies to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/openghg/openghg/compare/0.1.1...HEAD)
 
+### Added
+- Added dependencies in pyproject.toml. [#PR 14](https://github.com/openghg/openghg_calscales/pull/14)
+
 ## [0.1.1] - 2024-05-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "MIT License"}
 
+dependencies = [
+"pandas"
+"numpy"
+"networkx"
+"xarray"
+"sympy"]
+
 [project.urls]
 "Homepage" = "https://github.com/openghg/openghg_calscales"
 "Bug Tracker" = "https://github.com/openghg/openghg_calscales/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ requires-python = ">=3.9"
 license = {text = "MIT License"}
 
 dependencies = [
-"pandas"
-"numpy"
-"networkx"
-"xarray"
-"sympy"]
+"pandas",
+"numpy",
+"networkx",
+"xarray",
+"sympy",]
 
 [project.urls]
 "Homepage" = "https://github.com/openghg/openghg_calscales"


### PR DESCRIPTION
* **Summary of changes**
With PEP621 installing package does not ensure packages are installed if not passed explicitly as dependencies in the pyproject.toml. This is required to use openghg-calscales as package inside openghg.

* **Please check if the PR fulfills these requirements**

- [x] Closes #13 (Replace xxxx with the Github issue number)
- [x] [Tests added and passed](https://docs.openghg.org/development/python_devel.html#testing)
- [x] Added an entry in the latest `CHANGELOG.md` file
- [x] Added any new requirements to `requirements.txt` and `recipes/meta.yaml`
